### PR TITLE
Update HasJsonRelationships.php

### DIFF
--- a/src/HasJsonRelationships.php
+++ b/src/HasJsonRelationships.php
@@ -22,8 +22,17 @@ trait HasJsonRelationships
             return;
         }
 
-        if (array_key_exists(explode('->', $key)[0], $this->attributes)) {
-            return $this->getAttributeValue($key);
+        $keyPieces = explode('->', $key);
+
+        if(is_array($keyPieces)){
+            $attr = $keyPieces[0];
+            if(Str::contains($keyPieces[0], '[]')){
+                $attr = $keyPieces[1];
+                $key = str_replace('[]', '', $keyPieces[0]);
+            }
+            if (array_key_exists($attr, $this->attributes)) {
+                return $this->getAttributeValue($key);
+            }
         }
 
         return parent::getAttribute($key);


### PR DESCRIPTION
Allow the array of objects to be the value of the json field itself

options: is json the field in the examples below

These are the 3 scenarios that will cover all the bases. 

1.) options: `[1,2,3] | options->role_ids`

2.) options: `{"user_id": 5, "roles": [ {"role_id": 1, "active": false}, {"role_id": 2, "active": true} ] }  | options->roles[]->role_id
`

**NEW**
3.)  options: `[ {"role_id": 1, "active": false}, {"role_id": 2, "active": true}, {"role_id": 3, "active": false} ] | options[]->role_id `

There are times where user stores data like in the 3.) example. 

For 3.) the relationship would look like this ...  
`return $this->belongsToJson('App\Role', 'options[]->role_id');`

I tested with attach(), detach(), sync() and toggle() and everything seems to work per normal. Would be a great improvement as this would expand the use case to these three which are the only possible scenarios.