### PR TITLE
Filter null keys when getting foreign keys in BelongsToJson relationship

### DIFF
--- a/src/Relations/BelongsToJson.php
+++ b/src/Relations/BelongsToJson.php
@@ -195,6 +195,10 @@ class BelongsToJson extends BelongsTo
      */
     public function getForeignKeys()
     {
-        return (array) $this->child->{$this->foreignKey};
+        $keys = (array) $this->child->{$this->foreignKey};
+
+        return array_filter($keys, function($key) {
+            return $key !== null;
+        });
     }
 }

--- a/src/Relations/BelongsToJson.php
+++ b/src/Relations/BelongsToJson.php
@@ -49,7 +49,7 @@ class BelongsToJson extends BelongsTo
         $keys = [];
 
         foreach ($models as $model) {
-            $keys = array_merge($keys, (array) $model->{$this->foreignKey});
+            $keys = array_merge($keys, (array) $this->getForeignKeys($model));
         }
 
         sort($keys);
@@ -72,7 +72,7 @@ class BelongsToJson extends BelongsTo
         foreach ($models as $model) {
             $matches = [];
 
-            foreach ((array) $model->{$this->foreignKey} as $id) {
+            foreach ((array) $this->getForeignKeys($model) as $id) {
                 if (isset($dictionary[$id])) {
                     $matches[] = $dictionary[$id];
                 }
@@ -193,9 +193,11 @@ class BelongsToJson extends BelongsTo
      *
      * @return array
      */
-    public function getForeignKeys()
+    public function getForeignKeys(Model $model = null)
     {
-        $keys = (array) $this->child->{$this->foreignKey};
+        $model = $model ?: $this->child;
+
+        $keys = (array) $model->{$this->foreignKey};
 
         return array_filter($keys, function($key) {
             return $key !== null;

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -239,4 +239,11 @@ class BelongsToJsonTest extends TestCase
         $this->assertEquals([1, 3], $user->roles2->pluck('id')->all());
         $this->assertEquals([true, false], $user->roles2->pluck('pivot.role.active')->all());
     }
+
+    public function testForeignKeysDoNotIncludeNullValues()
+    {
+        $keys = User::first()->postsOnly()->getForeignKeys();
+
+        $this->assertEquals([1, 2], $keys);
+    }
 }

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -246,4 +246,13 @@ class BelongsToJsonTest extends TestCase
 
         $this->assertEquals([1, 2], $keys);
     }
+
+    public function testForeignKeysDoNotIncludeNullValuesWhenEagerLoading()
+    {
+        DB::enableQueryLog();
+
+        User::with('postsOnly')->get();
+
+        $this->assertStringEndsWith('(1, 2)', DB::getQueryLog()[1]['query']);
+    }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -30,7 +30,7 @@ class User extends Model
 
     public function postsOnly()
     {
-        return $this->belongsToJson(Role::class, 'options->posts_and_comments[]->post->id');
+        return $this->belongsToJson(Post::class, 'options->posts_and_comments[]->post->id');
     }
 
     public function teamMate()

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -28,6 +28,11 @@ class User extends Model
         return $this->belongsToJson(Role::class, 'options[]->role_id');
     }
 
+    public function postsOnly()
+    {
+        return $this->belongsToJson(Role::class, 'options->posts_and_comments[]->post->id');
+    }
+
     public function teamMate()
     {
         return $this->hasOneThrough(self::class, Team::class, 'options->owner_id', 'options->team_id');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -108,6 +108,13 @@ abstract class TestCase extends Base
                     ['role' => ['id' => 1, 'active' => true]],
                     ['role' => ['id' => 2, 'active' => false]],
                 ],
+                'posts_and_comments' => [
+                    ['post' => ['id' => 1, 'active' => true]],
+                    ['post' => ['id' => 2, 'active' => true]],
+                    ['comment' => ['id' => 3, 'active' => false]],
+                    ['comment' => ['id' => 4, 'active' => false]],
+                    ['comment' => ['id' => 5, 'active' => false]],
+                ],
             ],
         ]);
         User::create(['options' => ['team_id' => 1]]);


### PR DESCRIPTION
This pull request fixes the issue described in #34. It filters null foreign keys out in `BelongsToJson` relationship. 

