### PR TITLE
Fix: `morphTo()` not extracting JSON attribute values

### DIFF
--- a/src/HasJsonRelationships.php
+++ b/src/HasJsonRelationships.php
@@ -42,6 +42,21 @@ trait HasJsonRelationships
     }
 
     /**
+     * Get an attribute from the $attributes array.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function getAttributeFromArray($key)
+    {
+        if (Str::contains($key, '->')) {
+            return $this->getAttributeValue($key);
+        }
+
+        return parent::getAttributeFromArray($key);
+    }
+
+    /**
      * Get a plain attribute (not a relationship).
      *
      * @param string $key


### PR DESCRIPTION
In a [recent PR to the framework](https://github.com/laravel/framework/pull/35420) an edge-case as fixed. It prevented `morphTo` relationships to be properly handled if attribute names for `type` and `id` where also registered for casting.

Now, instead of trying to access the attribute values via _attribute casting_, they're accessed directly from the `$attributes` array (via `getAttributeFromArray()`).

This PR aims to fix a bug caused by the change of attribute value access.