### PR TITLE
Support AsCollection and AsArrayObject casts

### DIFF
--- a/src/Relations/BelongsToJson.php
+++ b/src/Relations/BelongsToJson.php
@@ -2,11 +2,13 @@
 
 namespace Staudenmeir\EloquentJsonRelations\Relations;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Enumerable;
 
 class BelongsToJson extends BelongsTo
 {
@@ -198,10 +200,31 @@ class BelongsToJson extends BelongsTo
     {
         $model = $model ?: $this->child;
 
-        $keys = (array) $model->{$this->foreignKey};
+        $keys = $this->getArrayableItems($model->{$this->foreignKey});
 
         return array_filter($keys, function ($key) {
             return $key !== null;
         });
+    }
+
+    /**
+     * Results array of items from Collection or Arrayable.
+     *
+     * @param  mixed  $items
+     * @return array
+     */
+    protected function getArrayableItems($items)
+    {
+        if (is_array($items)) {
+            return $items;
+        } elseif ($items instanceof Enumerable) {
+            return $items->all();
+        } elseif ($items instanceof Arrayable) {
+            return $items->toArray();
+        } elseif ($items instanceof Traversable) {
+            return iterator_to_array($items);
+        }
+
+        return (array) $items;
     }
 }

--- a/src/Relations/BelongsToJson.php
+++ b/src/Relations/BelongsToJson.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Enumerable;
+use Traversable;
 
 class BelongsToJson extends BelongsTo
 {

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Tests\Models\Post;
 use Tests\Models\Role;
 use Tests\Models\User;
+use Tests\Models\UserAsArrayObject;
+use Tests\Models\UserAsCollection;
 
 class BelongsToJsonTest extends TestCase
 {
@@ -252,10 +254,22 @@ class BelongsToJsonTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $user->options['roles'][2]);
     }
 
-    public function testForeignKeys()
+    /**
+     * @dataProvider foreignKeysDataProvider
+     */
+    public function testForeignKeys($user)
     {
-        $keys = User::first()->roles()->getForeignKeys();
+        $keys = $user::first()->roles()->getForeignKeys();
 
         $this->assertEquals([1, 2], $keys);
+    }
+
+    public function foreignKeysDataProvider()
+    {
+        return [
+            [User::class],
+            [UserAsCollection::class],
+            [UserAsArrayObject::class],
+        ];
     }
 }

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -266,10 +266,15 @@ class BelongsToJsonTest extends TestCase
 
     public function foreignKeysDataProvider()
     {
-        return [
+        $users = [
             [User::class],
-            [UserAsCollection::class],
-            [UserAsArrayObject::class],
         ];
+
+        if (class_exists('Illuminate\Database\Eloquent\Casts\AsArrayObject')) {
+            $users[] = [UserAsArrayObject::class];
+            $users[] = [UserAsCollection::class];
+        }
+
+        return $users;
     }
 }

--- a/tests/Models/UserAsArrayObject.php
+++ b/tests/Models/UserAsArrayObject.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+
+class UserAsArrayObject extends Model
+{
+    protected $table = 'users';
+
+    protected $casts = [
+        'options' => AsArrayObject::class
+    ];
+
+    public function roles()
+    {
+        return $this->belongsToJson(Role::class, 'options->role_ids');
+    }
+}

--- a/tests/Models/UserAsCollection.php
+++ b/tests/Models/UserAsCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+
+class UserAsCollection extends Model
+{
+    protected $table = 'users';
+
+    protected $casts = [
+        'options' => AsCollection::class
+    ];
+
+    public function roles()
+    {
+        return $this->belongsToJson(Role::class, 'options->role_ids');
+    }
+}


### PR DESCRIPTION
I spotted a bug that occurs silently when using the new `AsCollection` cast. The issue is [this line](https://github.com/staudenmeir/eloquent-json-relations/blob/master/src/Relations/BelongsToJson.php#L201), which casts the `Illuminate\Support\Collection` as an array. The result looks like this when dumped out: 
```
array:1 [
    "\x00*\x00items" => array:x [...]
]
```

I fixed the bug by adding a method that casts any instances of `Arrayable`, `Enumerable` and `Traversable` to arrays. I haven't noticed any issues with `ArrayObject`, but handling `Traversable` seemed sensible. The `getArrayableItems` method I added is basically a cutdown version of [what the Laravel Collection itself does](https://github.com/laravel/framework/blob/8dcc5aab239ef3f57b36766fa7aec45701ade255/src/Illuminate/Collections/Traits/EnumeratesValues.php#L917) to prepare data passed to its constructor.