### PR TITLE
create new relationship file and trait methods

### DIFF
--- a/src/HasJsonRelationships.php
+++ b/src/HasJsonRelationships.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
 use Staudenmeir\EloquentJsonRelations\Relations\BelongsToJson;
 use Staudenmeir\EloquentJsonRelations\Relations\HasManyJson;
+use Staudenmeir\EloquentJsonRelations\Relations\HasManyThroughJson;
 use Staudenmeir\EloquentJsonRelations\Relations\Postgres\BelongsTo as BelongsToPostgres;
 use Staudenmeir\EloquentJsonRelations\Relations\Postgres\HasMany as HasManyPostgres;
 use Staudenmeir\EloquentJsonRelations\Relations\Postgres\HasManyThrough as HasManyThroughPostgres;
@@ -281,6 +282,53 @@ trait HasJsonRelationships
             $instance->getTable().'.'.$foreignKey,
             $localKey
         );
+    }
+
+    /**
+     * Define has-many-through JSON relationship
+     *
+     * @param \Illuminate\Database\Eloquent\Model $related
+     * @param \Illuminate\Database\Eloquent\Model $through
+     * @param string $firstKey
+     * @param string $secondKey
+     * @param string $localKey
+     * @param string $secondLocalKey
+     * @return \Staudenmeir\EloquentJsonRelations\Relations\HasManyThroughJson
+     */
+    public function hasManyThroughJson($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
+    {
+        $through = new $through;
+        $firstKey = $firstKey ?: $this->getForeignKey();
+        $secondKey = $secondKey ?: $through->getForeignKey();
+
+        $query = $this->newRelatedInstance($related)->newQuery();
+        
+        return $this->newHasManyThroughJson(
+            $query,
+            $this,
+            $through,
+            $firstKey,
+            $secondKey,
+            $localKey ?: $this->getKeyName(),
+            $secondLocalKey ?: $through->getKeyName()
+        );
+    }
+
+    /**
+     * Instantiate a new hasManyThroughJson relationship.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param \Illuminate\Database\Eloquent\Model $farParent
+     * @param \Illuminate\Database\Eloquent\Model $through
+     * @param string $firstKey
+     * @param string $secondKey
+     * @param string $localKey
+     * @param string $secondLocalKey
+     * @return \Staudenmeir\EloquentJsonRelations\Relations\HasManyThroughJson
+     */
+    protected function newHasManyThroughJson(Builder $query, Model $farParent, Model $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey)
+    {
+        return new HasManyThroughJson($query, $farParent, $throughParent, $firstKey, $secondKey, $localKey, $secondLocalKey);
     }
 
     /**

--- a/src/Relations/HasManyThroughJson.php
+++ b/src/Relations/HasManyThroughJson.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Staudenmeir\EloquentJsonRelations\Relations;
+
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class HasManyThroughJson extends HasManyThrough
+{
+    /**
+     * Set the base constraints on the relation query.
+     *
+     * @return void
+     */
+    public function addConstraints()
+    {
+        
+        $localValue = $this->farParent[$this->localKey];
+        $this->performJoin();
+
+        if (static::$constraints) {
+            $this->query->whereJsonContains($this->getQualifiedFirstKeyName(), $localValue);
+        }
+    }
+
+   
+}


### PR DESCRIPTION
New relationship class for hasManyThroughJson eloquent relationships

Functions same as hasManyThrough, but where primary key of the Model is present in a json array column of a second table. 

Usage like so:

```
    namespace App\Models\Content\Episode;

    use Staudenmeir\EloquentJsonRelations\HasJsonRelationships;

    class Episodes extends Model{
        use HasJsonRelationships;

        public function acquisitionBatches(){
            return $this->hasManyThroughJson(
                AcquisitionBatch::class,
                AcquisitionBatchItem::class,
                'episode_ids', // this one is json
                'id',
                'id',
                'acquisition_batch_id'
            );
    }
```
 

