### PR TITLE
Add support for Arrayable object columns

### DIFF
--- a/src/Relations/Traits/IsJsonRelation.php
+++ b/src/Relations/Traits/IsJsonRelation.php
@@ -2,6 +2,7 @@
 
 namespace Staudenmeir\EloquentJsonRelations\Relations\Traits;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -75,6 +76,10 @@ trait IsJsonRelation
     protected function pivotRelation(Model $model, Model $parent, callable $callback)
     {
         $records = $callback($model, $parent);
+
+        if ($records instanceof Arrayable) {
+            $records = $records->toArray();
+        }
 
         $attributes = $this->pivotAttributes($model, $parent, $records);
 

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -186,9 +186,9 @@ class BelongsToJsonTest extends TestCase
     }
 
     /**
-     * @dataProvider objectColumnProviders
+     * @dataProvider userModelProvider
      */
-    public function testAttachWithObjectsInColumn($userModel)
+    public function testAttachWithObjectsInColumn(string $userModel)
     {
         $user = (new $userModel())->roles3()->attach([1 => ['active' => true], 2 => ['active' => false]]);
 
@@ -260,28 +260,25 @@ class BelongsToJsonTest extends TestCase
     }
 
     /**
-     * @dataProvider objectColumnProviders
+     * @dataProvider userModelProvider
      */
-    public function testForeignKeys($user)
+    public function testForeignKeys(string $userModel)
     {
-        $keys = $user::find(21)->roles()->getForeignKeys();
+        $keys = $userModel::find(21)->roles()->getForeignKeys();
 
         $this->assertEquals([1, 2], $keys);
     }
 
-    public function objectColumnProviders()
+    public function userModelProvider(): array
     {
         $users = [
             [User::class],
+            [UserAsArrayable::class],
         ];
 
         if (class_exists('Illuminate\Database\Eloquent\Casts\AsArrayObject')) {
             $users[] = [UserAsArrayObject::class];
             $users[] = [UserAsCollection::class];
-        }
-
-        if (interface_exists(Arrayable::class)) {
-            $users[] = [UserAsArrayable::class];
         }
 
         return $users;

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -9,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Tests\Models\Post;
 use Tests\Models\Role;
 use Tests\Models\User;
+use Tests\Models\UserAsArrayable;
 use Tests\Models\UserAsArrayObject;
 use Tests\Models\UserAsCollection;
 
@@ -183,9 +185,12 @@ class BelongsToJsonTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $user->options['roles'][3]);
     }
 
-    public function testAttachWithObjectsInColumn()
+    /**
+     * @dataProvider objectColumnProviders
+     */
+    public function testAttachWithObjectsInColumn($userModel)
     {
-        $user = (new User())->roles3()->attach([1 => ['active' => true], 2 => ['active' => false]]);
+        $user = (new $userModel())->roles3()->attach([1 => ['active' => true], 2 => ['active' => false]]);
 
         $this->assertEquals([1, 2], $user->roles3->pluck('id')->all());
         $this->assertEquals([true, false], $user->roles3->pluck('pivot.active')->all());
@@ -255,7 +260,7 @@ class BelongsToJsonTest extends TestCase
     }
 
     /**
-     * @dataProvider foreignKeysDataProvider
+     * @dataProvider objectColumnProviders
      */
     public function testForeignKeys($user)
     {
@@ -264,7 +269,7 @@ class BelongsToJsonTest extends TestCase
         $this->assertEquals([1, 2], $keys);
     }
 
-    public function foreignKeysDataProvider()
+    public function objectColumnProviders()
     {
         $users = [
             [User::class],
@@ -273,6 +278,10 @@ class BelongsToJsonTest extends TestCase
         if (class_exists('Illuminate\Database\Eloquent\Casts\AsArrayObject')) {
             $users[] = [UserAsArrayObject::class];
             $users[] = [UserAsCollection::class];
+        }
+
+        if (interface_exists(Arrayable::class)) {
+            $users[] = [UserAsArrayable::class];
         }
 
         return $users;

--- a/tests/Casts/ArrayableCast.php
+++ b/tests/Casts/ArrayableCast.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Casts;
+
+use ArrayIterator;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+
+class ArrayableCast extends ArrayIterator implements CastsAttributes, Arrayable
+{
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return null === $value ? new static([]) : new static(json_decode($value, true));
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value instanceof static ?json_encode($value->toArray()) : json_encode($value);
+    }
+
+    public function toArray()
+    {
+        return $this->getArrayCopy();
+    }
+}

--- a/tests/Models/UserAsArrayObject.php
+++ b/tests/Models/UserAsArrayObject.php
@@ -17,4 +17,9 @@ class UserAsArrayObject extends Model
     {
         return $this->belongsToJson(Role::class, 'options->role_ids');
     }
+
+    public function roles3(): BelongsToJson
+    {
+        return $this->belongsToJson(Role::class, 'options[]->role_id');
+    }
 }

--- a/tests/Models/UserAsArrayable.php
+++ b/tests/Models/UserAsArrayable.php
@@ -2,10 +2,8 @@
 
 namespace Tests\Models;
 
-use ArrayIterator;
-use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Contracts\Support\Arrayable;
 use Staudenmeir\EloquentJsonRelations\Relations\BelongsToJson;
+use Tests\Casts\ArrayableCast;
 
 class UserAsArrayable extends User
 {
@@ -23,23 +21,5 @@ class UserAsArrayable extends User
     public function roles3(): BelongsToJson
     {
         return $this->belongsToJson(Role::class, 'options[]->role_id');
-    }
-}
-
-class ArrayableCast extends ArrayIterator implements CastsAttributes, Arrayable
-{
-    public function get($model, string $key, $value, array $attributes)
-    {
-        return null === $value ? new static([]) : new static(json_decode($value, true));
-    }
-
-    public function set($model, string $key, $value, array $attributes)
-    {
-        return $value instanceof static ? json_encode($value->toArray()) : json_encode($value);
-    }
-
-    public function toArray()
-    {
-        return $this->getArrayCopy();
     }
 }

--- a/tests/Models/UserAsArrayable.php
+++ b/tests/Models/UserAsArrayable.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Models;
+
+use ArrayIterator;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+use Staudenmeir\EloquentJsonRelations\Relations\BelongsToJson;
+
+class UserAsArrayable extends User
+{
+    protected $table = 'users';
+
+    protected $casts = [
+        'options' => ArrayableCast::class,
+    ];
+
+    public function roles(): BelongsToJson
+    {
+        return $this->belongsToJson(Role::class, 'options->role_ids');
+    }
+
+    public function roles3(): BelongsToJson
+    {
+        return $this->belongsToJson(Role::class, 'options[]->role_id');
+    }
+}
+
+class ArrayableCast extends ArrayIterator implements CastsAttributes, Arrayable
+{
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return null === $value ? new static([]) : new static(json_decode($value, true));
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value instanceof static ? json_encode($value->toArray()) : json_encode($value);
+    }
+
+    public function toArray()
+    {
+        return $this->getArrayCopy();
+    }
+}

--- a/tests/Models/UserAsCollection.php
+++ b/tests/Models/UserAsCollection.php
@@ -17,4 +17,9 @@ class UserAsCollection extends Model
     {
         return $this->belongsToJson(Role::class, 'options->role_ids');
     }
+
+    public function roles3(): BelongsToJson
+    {
+        return $this->belongsToJson(Role::class, 'options[]->role_id');
+    }
 }


### PR DESCRIPTION
This PR enables support for object columns that support Laravel's `Arrayable` interface.

When using https://github.com/spatie/laravel-data objects/collections as eloquent casts, there was an incompatibility with `IsJsonRelation` that expects the column to be an array type. This change simply calls `toArray` if the collection can convert to an array.