### PR TITLE
Add missing getRelatedKeyName

### DIFF
--- a/src/Relations/BelongsToJson.php
+++ b/src/Relations/BelongsToJson.php
@@ -257,4 +257,14 @@ class BelongsToJson extends BelongsTo implements ConcatenableRelation
 
         return (new BaseCollection($model->{$this->foreignKey}))->filter(fn ($key) => $key !== null)->all();
     }
+
+    /**
+     * Get the related key for the relationship.
+     *
+     * @return string
+     */
+    public function getRelatedKeyName()
+    {
+        return $this->ownerKey;
+    }
 }

--- a/tests/BelongsToJsonTest.php
+++ b/tests/BelongsToJsonTest.php
@@ -275,6 +275,13 @@ class BelongsToJsonTest extends TestCase
         $this->assertEquals([1, 2], $keys);
     }
 
+    public function testGetRelatedKeyName()
+    {
+        $relatedKeyName = (new User())->roles()->getRelatedKeyName();
+
+        $this->assertEquals('id', $relatedKeyName);
+    }
+
     public static function idRelationProvider(): array
     {
         return [


### PR DESCRIPTION
I'm using Filament, and it seems to use the `getRelatedKeyName()` method on a ` BelongsToMany` relationship.
This fixes the issue. :)

It should be `ownerKey` right? Laravel seems to call this `relatedKey`.

Thanks!